### PR TITLE
Added functionality to print failure assertions only

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -43,18 +43,32 @@ function write(results, options, done) {
             title: a.message,
             value: a.failure
           })
+          if(options.printFailureAssertionOnly){
+              attachments.push({
+                color: color,
+                title: testName,
+                footer: moduleName,
+                text: text,
+                fields: fields
+            });
+          }
         }
       })
 
-      attachments.push({
-        color: color,
-        title: testName,
-        footer: moduleName,
-        text: text,
-        fields: fields
-      });
+       if(!options.printFailureAssertionOnly){
+          attachments.push({
+            color: color,
+            title: testName,
+            footer: moduleName,
+            text: text,
+            fields: fields
+        });
+      }
     });
   });
+
+
+
   wh.send(assign({
     attachments: attachments
   }, message), done);


### PR DESCRIPTION
- Added functionality to print failed assertions only
- Usually, you are not interested in reviewing passed assertions
