### PR TITLE
Adds options to send only on failure or send only failed tests.

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -4,6 +4,7 @@ var IncomingWebhook = require('@slack/client').IncomingWebhook
 
 function write(results, options, done) {
   var webhookURL = process.env.SLACK_WEBHOOK_URL || options.slack_webhook_url || (options.globals || {}).slack_webhook_url
+    , sendOnlyOnFailure = options.slack_send_only_on_failure || (options.globals || {}).slack_slack_send_only_on_failure || false
     , modules = results.modules || {}
     , attachments = []
     , message, wh, completed, skipped, color
@@ -13,6 +14,10 @@ function write(results, options, done) {
     return done();
   }
   wh = new IncomingWebhook(webhookURL);
+  
+  if(sendOnlyOnFailure && results.failed < 1){
+    return done();
+  }
 
   message = options.slack_message || (options.globals || {}).slack_message || {};
   if (typeof message === 'function') {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -5,6 +5,7 @@ var IncomingWebhook = require('@slack/client').IncomingWebhook
 function write(results, options, done) {
   var webhookURL = process.env.SLACK_WEBHOOK_URL || options.slack_webhook_url || (options.globals || {}).slack_webhook_url
     , sendOnlyOnFailure = options.slack_send_only_on_failure || (options.globals || {}).slack_slack_send_only_on_failure || false
+    , sendOnlyFailedTests = options.slack_send_only_failed_tests || (options.globals || {}).slack_send_only_failed_tests || false
     , modules = results.modules || {}
     , attachments = []
     , message, wh, completed, skipped, color
@@ -41,6 +42,10 @@ function write(results, options, done) {
         , text = assertions.length + ' assertions, ' + test.time + ' seconds elapsed'
         , fields = []
         ;
+
+      if(sendOnlyFailedTests && failed < 1){
+        return;
+      }
 
       assertions.forEach(function(a) {
         if (a.failure) {

--- a/tests/reporter_test.js
+++ b/tests/reporter_test.js
@@ -67,6 +67,18 @@ describe('Reporter', function() {
         fields: []
       }
     ];
+    expectedAttachmentsOnlyFailed = [
+      {
+        color: 'danger',
+        title: 'Example Test',
+        footer: '01_my_examples',
+        text: '3 assertions, 21.77 seconds elapsed',
+        fields: [{
+          title: 'Test 3',
+          value: 'Expected "true" but got: "false"'
+        }]
+      }
+    ];
     subject = null;
   });
 
@@ -116,6 +128,27 @@ describe('Reporter', function() {
           expect(sentData).to.deep.equal({
             text: 'Test completed, passed 2, failed 1',
             attachments: expectedAttachments
+          });
+          done();
+        });
+      });
+      
+      it('with send only failed tests', function(done) {
+        options = function() {
+          return {
+            globals: {
+              slack_webhook_url: 'https://www.foo.com/bar',
+              slack_message: function(results, options) {
+                return 'Test completed, passed ' + results.passed + ', failed ' + results.failed
+              },
+              slack_send_only_failed_tests: true
+            }
+          }
+        };
+        subject(function() {
+          expect(sentData).to.deep.equal({
+            text: 'Test completed, passed 2, failed 1',
+            attachments: expectedAttachmentsOnlyFailed
           });
           done();
         });

--- a/tests/reporter_test.js
+++ b/tests/reporter_test.js
@@ -120,6 +120,27 @@ describe('Reporter', function() {
           done();
         });
       });
+      
+      it('with send only on failure', function(done) {
+        options = function() {
+          return {
+            globals: {
+              slack_webhook_url: 'https://www.foo.com/bar',
+              slack_message: function(results, options) {
+                return 'Test completed, passed ' + results.passed + ', failed ' + results.failed
+              },
+              slack_send_only_on_failure: true
+            }
+          }
+        };
+        subject(function() {
+          expect(sentData).to.deep.equal({
+            text: 'Test completed, passed 2, failed 1',
+            attachments: expectedAttachments
+          });
+          done();
+        });
+      });
     });
   }
 


### PR DESCRIPTION
To not be bombarded by slack messages, an option to send to slack only if the tests failed was added along with another option to send only the failed tests.